### PR TITLE
Avoid raising errors in database operations

### DIFF
--- a/mcm/couchdb_layer/mcm_database.py
+++ b/mcm/couchdb_layer/mcm_database.py
@@ -195,13 +195,16 @@ class database:
         Non existing documents are changed with None
         Order is preserved
         """
-        request = self.couch_request('%s/_bulk_get' % (self.db_name),
-                                     method='POST',
-                                     data={'docs': [{'id': x} for x in ids]})
-        data = self.opener.open(request)
-        results = json.loads(data.read(self.MAX_READ))['results']
-        results = [r['docs'][-1]['ok'] for r in results if r.get('docs') if r['docs'][-1].get('ok')]
-        return results
+        try:
+            request = self.couch_request('%s/_bulk_get' % (self.db_name),
+                                        method='POST',
+                                        data={'docs': [{'id': x} for x in ids]})
+            data = self.opener.open(request)
+            results = json.loads(data.read(self.MAX_READ))['results']
+            results = [r['docs'][-1]['ok'] for r in results if r.get('docs') if r['docs'][-1].get('ok')]
+            return results
+        except ValueError:
+            return []
 
     def document_exists(self, prepid, include_deleted=False):
         """
@@ -319,26 +322,39 @@ class database:
 
         self.logger.debug('Query view %s', url)
         request = self.couch_request(url)
+        try:
+            data = self.opener.open(request).read(self.MAX_READ)
+            # Tell the user when MAX_READ is reached
+            if len(data) == self.MAX_READ:
+                error_msg = (
+                    'The database returned too much data. '
+                    'Use a better query and pagination to collect a smaller set of results'
+                )
+                self.logger.error(error_msg)
+                if with_total_rows:
+                    return {'rows': [], 'total_rows': 0, 'message': error_msg}
 
-        data = self.opener.open(request).read(self.MAX_READ)
+                return []
 
-        # Tell the user when MAX_READ is reached
-        if len(data) == self.MAX_READ:
-            raise ValueError('The database returned too much data. Use a better query and pagination to collect a smaller set of results')
+            data = json.loads(data)
+            if options.get('include_docs'):
+                rows = [r['doc'] for r in data.get('rows', [])]
+            elif design_doc == 'unique':
+                rows = [r['key'] for r in data.get('rows', [])]
+            else:
+                rows = [r['value'] for r in data.get('rows', [])]
 
-        data = json.loads(data)
-        if options.get('include_docs'):
-            rows = [r['doc'] for r in data.get('rows', [])]
-        elif design_doc == 'unique':
-            rows = [r['key'] for r in data.get('rows', [])]
-        else:
-            rows = [r['value'] for r in data.get('rows', [])]
+            if with_total_rows:
+                total_rows = data.get('total_rows', 0)
+                return {'rows': rows, 'total_rows': total_rows}
 
-        if with_total_rows:
-            total_rows = data.get('total_rows', 0)
-            return {'rows': rows, 'total_rows': total_rows}
+            return rows
+        except Exception as ex:
+            self.logger.error('Error querying view %s: %s', url, ex)
+            if with_total_rows:
+                return {'rows': [], 'total_rows': 0}
 
-        return rows
+            return []
 
     def get_all(self, page=-1, limit=20, with_total_rows=False):
         """
@@ -438,8 +454,6 @@ class database:
         """
         Query couchdb-lucene with given query dict. By default, returns a list of dicts.
         If total_rows is True, returns a dict of results "rows" and number of "total_rows" instead.
-
-        Raises on error.
         """
         limit, skip = self.pagify(page, limit)
         query = self.make_query(query_dict)
@@ -475,36 +489,40 @@ class database:
         for attempt in range(1, self.max_attempts + 1):
             try:
                 data = self.opener.open(lucene_request).read(self.MAX_READ)
+                # Tell the user when MAX_READ is reached
+                if len(data) == self.MAX_READ:
+                    error_msg = (
+                        'The database returned too much data. '
+                        'Use a better query and pagination to collect a smaller set of results'
+                    )
+                    self.logger.error(error_msg)
+                    if total_rows:
+                        return {'rows': [], 'total_rows': 0, 'message': error_msg}
+
+                    return []
+
+                data = json.loads(data)
+                if total_rows:
+                    return {'rows': [r['doc'] for r in data.get('rows', [])],
+                            'total_rows': data.get('total_rows', 0)}
+
+                return [r['doc'] for r in data.get('rows', [])]
+
             except urllib2.HTTPError as http_error:
                 code = http_error.code
                 self.logger.error('HTTP error %s %s: %s', url, options, http_error)
                 if 400 <= code < 500:
                     # If it's HTTP 4xx - bad request, no point in retry
-                    raise
+                    break
 
                 if attempt < self.max_attempts:
                     sleep = 2 ** attempt
                     time.sleep(sleep)
-                else:
-                    raise
             except Exception as ex:
                 self.logger.error('Error %s %s: %s', url, options, ex)
                 if attempt < self.max_attempts:
                     sleep = 2 ** attempt
                     time.sleep(sleep)
-                else:
-                    raise
-
-            # Tell the user when MAX_READ is reached
-            if len(data) == self.MAX_READ:
-                raise ValueError('The database returned too much data. Use a better query and pagination to collect a smaller set of results')
-
-            data = json.loads(data)
-            if total_rows:
-                return {'rows': [r['doc'] for r in data.get('rows', [])],
-                        'total_rows': data.get('total_rows', 0)}
-
-            return [r['doc'] for r in data.get('rows', [])]
 
         if total_rows:
             return {'rows': [],

--- a/mcm/couchdb_layer/mcm_database.py
+++ b/mcm/couchdb_layer/mcm_database.py
@@ -17,6 +17,8 @@ class database:
     # Cache timeout in seconds
     CACHE_TIMEOUT = 60 * 60
     IP_CACHE_TIMEOUT = 15 * 60
+    MAX_READ = int(10e6)  # 10MB should be enough for anyone
+
     cache = SimpleCache()
     ip_cache = SimpleCache()
 
@@ -128,11 +130,11 @@ class database:
         for attempt in range(1, self.max_attempts + 1):
             try:
                 data = self.opener.open(db_request)
-                return json.loads(data.read())
+                return json.loads(data.read(self.MAX_READ))
             except urllib2.HTTPError as http_error:
                 code = http_error.code
                 if code == 404 and include_deleted:
-                    data = http_error.read()
+                    data = http_error.read(self.MAX_READ)
                     # Database returned 404 - not found
                     # Document might have never existed or it could be deleted
                     data_json = json.loads(data)
@@ -197,7 +199,7 @@ class database:
                                      method='POST',
                                      data={'docs': [{'id': x} for x in ids]})
         data = self.opener.open(request)
-        results = json.loads(data.read())['results']
+        results = json.loads(data.read(self.MAX_READ))['results']
         results = [r['docs'][-1]['ok'] for r in results if r.get('docs') if r['docs'][-1].get('ok')]
         return results
 
@@ -261,7 +263,7 @@ class database:
         self.logger.info('Saving "%s" (%s) in "%s"...', doc_id, doc_rev, self.db_name)
         request = self.couch_request(self.db_name, 'POST', data=doc)
         try:
-            data = self.opener.open(request).read()
+            data = self.opener.open(request).read(self.MAX_READ)
             data = json.loads(data)
             success = data.get('ok') is True
             if not success:
@@ -278,7 +280,11 @@ class database:
         """
         if page_num < 0:
             # Page <0 means "all", but it still has to be limited to something
-            return 9999, 0
+            return 1000, 0
+
+        if limit < 0 or limit > 1000:
+            # Always enforce a limit
+            limit = 1000
 
         skip = limit * page_num
         return limit, skip
@@ -313,26 +319,26 @@ class database:
 
         self.logger.debug('Query view %s', url)
         request = self.couch_request(url)
-        try:
-            data = json.loads(self.opener.open(request).read())
-            if options.get('include_docs'):
-                rows = [r['doc'] for r in data.get('rows', [])]
-            elif design_doc == 'unique':
-                rows = [r['key'] for r in data.get('rows', [])]
-            else:
-                rows = [r['value'] for r in data.get('rows', [])]
 
-            if with_total_rows:
-                total_rows = data.get('total_rows', 0)
-                return {'rows': rows, 'total_rows': total_rows}
+        data = self.opener.open(request).read(self.MAX_READ)
 
-            return rows
-        except Exception as ex:
-            self.logger.error('Error querying view %s: %s', url, ex)
-            if with_total_rows:
-                return {'rows': [], 'total_rows': 0}
+        # Tell the user when MAX_READ is reached
+        if len(data) == self.MAX_READ:
+            raise ValueError('The database returned too much data. Use a better query and pagination to collect a smaller set of results')
 
-            return []
+        data = json.loads(data)
+        if options.get('include_docs'):
+            rows = [r['doc'] for r in data.get('rows', [])]
+        elif design_doc == 'unique':
+            rows = [r['key'] for r in data.get('rows', [])]
+        else:
+            rows = [r['value'] for r in data.get('rows', [])]
+
+        if with_total_rows:
+            total_rows = data.get('total_rows', 0)
+            return {'rows': rows, 'total_rows': total_rows}
+
+        return rows
 
     def get_all(self, page=-1, limit=20, with_total_rows=False):
         """
@@ -430,8 +436,10 @@ class database:
 
     def search(self, query_dict, page=0, limit=20, include_fields=None, total_rows=False, sort=None, sort_asc=True):
         """
-        Query couchdb-lucene with given query dict
-        Return a dict of results "rows" and number of "total_rows"
+        Query couchdb-lucene with given query dict. By default, returns a list of dicts.
+        If total_rows is True, returns a dict of results "rows" and number of "total_rows" instead.
+
+        Raises on error.
         """
         limit, skip = self.pagify(page, limit)
         query = self.make_query(query_dict)
@@ -466,29 +474,37 @@ class database:
                                              data=options)
         for attempt in range(1, self.max_attempts + 1):
             try:
-                data = self.opener.open(lucene_request)
-                data = json.loads(data.read())
-                if total_rows:
-                    return {'rows': [r['doc'] for r in data.get('rows', [])],
-                            'total_rows': data.get('total_rows', 0)}
-
-                return [r['doc'] for r in data.get('rows', [])]
-
+                data = self.opener.open(lucene_request).read(self.MAX_READ)
             except urllib2.HTTPError as http_error:
                 code = http_error.code
                 self.logger.error('HTTP error %s %s: %s', url, options, http_error)
                 if 400 <= code < 500:
                     # If it's HTTP 4xx - bad request, no point in retry
-                    break
+                    raise
 
                 if attempt < self.max_attempts:
                     sleep = 2 ** attempt
                     time.sleep(sleep)
+                else:
+                    raise
             except Exception as ex:
                 self.logger.error('Error %s %s: %s', url, options, ex)
                 if attempt < self.max_attempts:
                     sleep = 2 ** attempt
                     time.sleep(sleep)
+                else:
+                    raise
+
+            # Tell the user when MAX_READ is reached
+            if len(data) == self.MAX_READ:
+                raise ValueError('The database returned too much data. Use a better query and pagination to collect a smaller set of results')
+
+            data = json.loads(data)
+            if total_rows:
+                return {'rows': [r['doc'] for r in data.get('rows', [])],
+                        'total_rows': data.get('total_rows', 0)}
+
+            return [r['doc'] for r in data.get('rows', [])]
 
         if total_rows:
             return {'rows': [],

--- a/mcm/couchdb_layer/mcm_database.py
+++ b/mcm/couchdb_layer/mcm_database.py
@@ -17,8 +17,6 @@ class database:
     # Cache timeout in seconds
     CACHE_TIMEOUT = 60 * 60
     IP_CACHE_TIMEOUT = 15 * 60
-    MAX_READ = int(10e6)  # 10MB should be enough for anyone
-
     cache = SimpleCache()
     ip_cache = SimpleCache()
 
@@ -130,11 +128,11 @@ class database:
         for attempt in range(1, self.max_attempts + 1):
             try:
                 data = self.opener.open(db_request)
-                return json.loads(data.read(self.MAX_READ))
+                return json.loads(data.read())
             except urllib2.HTTPError as http_error:
                 code = http_error.code
                 if code == 404 and include_deleted:
-                    data = http_error.read(self.MAX_READ)
+                    data = http_error.read()
                     # Database returned 404 - not found
                     # Document might have never existed or it could be deleted
                     data_json = json.loads(data)
@@ -199,7 +197,7 @@ class database:
                                      method='POST',
                                      data={'docs': [{'id': x} for x in ids]})
         data = self.opener.open(request)
-        results = json.loads(data.read(self.MAX_READ))['results']
+        results = json.loads(data.read())['results']
         results = [r['docs'][-1]['ok'] for r in results if r.get('docs') if r['docs'][-1].get('ok')]
         return results
 
@@ -263,7 +261,7 @@ class database:
         self.logger.info('Saving "%s" (%s) in "%s"...', doc_id, doc_rev, self.db_name)
         request = self.couch_request(self.db_name, 'POST', data=doc)
         try:
-            data = self.opener.open(request).read(self.MAX_READ)
+            data = self.opener.open(request).read()
             data = json.loads(data)
             success = data.get('ok') is True
             if not success:
@@ -280,11 +278,7 @@ class database:
         """
         if page_num < 0:
             # Page <0 means "all", but it still has to be limited to something
-            return 1000, 0
-
-        if limit < 0 or limit > 1000:
-            # Always enforce a limit
-            limit = 1000
+            return 9999, 0
 
         skip = limit * page_num
         return limit, skip
@@ -319,26 +313,26 @@ class database:
 
         self.logger.debug('Query view %s', url)
         request = self.couch_request(url)
+        try:
+            data = json.loads(self.opener.open(request).read())
+            if options.get('include_docs'):
+                rows = [r['doc'] for r in data.get('rows', [])]
+            elif design_doc == 'unique':
+                rows = [r['key'] for r in data.get('rows', [])]
+            else:
+                rows = [r['value'] for r in data.get('rows', [])]
 
-        data = self.opener.open(request).read(self.MAX_READ)
+            if with_total_rows:
+                total_rows = data.get('total_rows', 0)
+                return {'rows': rows, 'total_rows': total_rows}
 
-        # Tell the user when MAX_READ is reached
-        if len(data) == self.MAX_READ:
-            raise ValueError('The database returned too much data. Use a better query and pagination to collect a smaller set of results')
+            return rows
+        except Exception as ex:
+            self.logger.error('Error querying view %s: %s', url, ex)
+            if with_total_rows:
+                return {'rows': [], 'total_rows': 0}
 
-        data = json.loads(data)
-        if options.get('include_docs'):
-            rows = [r['doc'] for r in data.get('rows', [])]
-        elif design_doc == 'unique':
-            rows = [r['key'] for r in data.get('rows', [])]
-        else:
-            rows = [r['value'] for r in data.get('rows', [])]
-
-        if with_total_rows:
-            total_rows = data.get('total_rows', 0)
-            return {'rows': rows, 'total_rows': total_rows}
-
-        return rows
+            return []
 
     def get_all(self, page=-1, limit=20, with_total_rows=False):
         """
@@ -436,10 +430,8 @@ class database:
 
     def search(self, query_dict, page=0, limit=20, include_fields=None, total_rows=False, sort=None, sort_asc=True):
         """
-        Query couchdb-lucene with given query dict. By default, returns a list of dicts.
-        If total_rows is True, returns a dict of results "rows" and number of "total_rows" instead.
-
-        Raises on error.
+        Query couchdb-lucene with given query dict
+        Return a dict of results "rows" and number of "total_rows"
         """
         limit, skip = self.pagify(page, limit)
         query = self.make_query(query_dict)
@@ -474,37 +466,29 @@ class database:
                                              data=options)
         for attempt in range(1, self.max_attempts + 1):
             try:
-                data = self.opener.open(lucene_request).read(self.MAX_READ)
+                data = self.opener.open(lucene_request)
+                data = json.loads(data.read())
+                if total_rows:
+                    return {'rows': [r['doc'] for r in data.get('rows', [])],
+                            'total_rows': data.get('total_rows', 0)}
+
+                return [r['doc'] for r in data.get('rows', [])]
+
             except urllib2.HTTPError as http_error:
                 code = http_error.code
                 self.logger.error('HTTP error %s %s: %s', url, options, http_error)
                 if 400 <= code < 500:
                     # If it's HTTP 4xx - bad request, no point in retry
-                    raise
+                    break
 
                 if attempt < self.max_attempts:
                     sleep = 2 ** attempt
                     time.sleep(sleep)
-                else:
-                    raise
             except Exception as ex:
                 self.logger.error('Error %s %s: %s', url, options, ex)
                 if attempt < self.max_attempts:
                     sleep = 2 ** attempt
                     time.sleep(sleep)
-                else:
-                    raise
-
-            # Tell the user when MAX_READ is reached
-            if len(data) == self.MAX_READ:
-                raise ValueError('The database returned too much data. Use a better query and pagination to collect a smaller set of results')
-
-            data = json.loads(data)
-            if total_rows:
-                return {'rows': [r['doc'] for r in data.get('rows', [])],
-                        'total_rows': data.get('total_rows', 0)}
-
-            return [r['doc'] for r in data.get('rows', [])]
 
         if total_rows:
             return {'rows': [],

--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -1344,7 +1344,14 @@ class request(json_base):
         prepid = self.get_attribute('prepid')
         member_of_campaign = self.get_attribute('member_of_campaign')
         scram_arch = self.get_scram_arch().lower()
-        bash_file = ['#!/bin/bash', '']
+        bash_file = [
+            '#!/bin/bash', 
+            '',
+            '# Binds for singularity containers',
+            '# Mount /afs, /eos, /cvmfs, /etc/grid-security for xrootd',
+            "export APPTAINER_BINDPATH='/afs,/cvmfs,/cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security,/eos,/etc/pki/ca-trust,/run/user,/var/run/user'",
+            '',
+        ]
 
         if not for_validation or automatic_validation:
             bash_file += ['#############################################################',
@@ -1378,11 +1385,37 @@ class request(json_base):
         run_gen_script = for_validation and self.should_run_gen_script() and (threads == 1 or threads is None)
         self.logger.info('Should %s run GEN script: %s' % (prepid, 'YES' if run_gen_script else 'NO'))
         if run_gen_script:
+            # Run CMS GEN script using Apptainer containers
+            # and an isolated `venv`
+            cms_gen_file = '%s_gen_script.sh' % (prepid)
+            cms_gen_os = 'el9:x86_64'
+            cms_gen_python = 'python3.9'
+            cms_gen_venv = 'cms_gen_venv_%s' % (prepid)
+            mcm_rest_client = 'git+https://github.com/cms-PdmV/mcm_scripts'
+
+            bash_file += [
+                'cat <<\'EndOfGenScriptFile\' > %s' % (cms_gen_file),
+                '#!/bin/bash',
+                '',
+                'echo "Running CMS GEN request script using cms-sw containers. Architecture: %s"' % (cms_gen_os),
+                '%s -m venv %s && source ./%s/bin/activate' % (cms_gen_python, cms_gen_venv, cms_gen_venv),
+                '',
+                '# Install the PdmV REST client',
+                'pip install %s &> /dev/null' % (mcm_rest_client),
+                '',
+                'echo "Packages installed"',
+                'pip freeze',
+                'echo ""',
+                '',
+            ]
+
             # Download the script
             bash_file += ['# GEN Script begin',
                           'rm -f request_fragment_check.py',
                           'wget -q https://raw.githubusercontent.com/cms-sw/genproductions/master/bin/utils/request_fragment_check.py',
-                          'chmod +x request_fragment_check.py']
+                          'chmod +x request_fragment_check.py',
+                          '',]
+            
             # Checking script invocation
             request_fragment_check = './request_fragment_check.py --bypass_status --prepid %s' % (prepid)
             if is_dev:
@@ -1405,6 +1438,21 @@ class request(json_base):
 
             # Execute the GEN script
             bash_file += [request_fragment_check]
+            
+            # Close the CMS GEN subscript and execute it using singularity
+            bash_file += [
+                '',
+                '# End of CMS GEN script file: %s' % (cms_gen_file),
+                'EndOfGenScriptFile',
+                'chmod +x %s' % (cms_gen_file),
+                '',
+            ]
+            bash_file += [
+                '# Run in singularity container',
+                'singularity run --home $PWD:$PWD /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/%s $(echo $(pwd)/%s)' % (cms_gen_os, cms_gen_file),
+                '',
+            ]
+
             # Get exit code of GEN script
             bash_file += ['GEN_ERR=$?']
             if automatic_validation:
@@ -1700,15 +1748,13 @@ class request(json_base):
             # Validation will run on CMS CAF nodes (HTCondor, lxplus)
             bash_file += [
                 '# Run in singularity container',
-                '# Mount afs, eos, cvmfs',
-                '# Mount /etc/grid-security for xrootd',
                 'export SINGULARITY_CACHEDIR="/tmp/$(whoami)/singularity"',
-                'singularity run -B /afs -B /eos -B /cvmfs -B /etc/grid-security -B /etc/pki/ca-trust --home $PWD:$PWD /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/$CONTAINER_NAME $(echo $(pwd)/%s)' % (test_file_name)
+                'singularity run --home $PWD:$PWD /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/$CONTAINER_NAME $(echo $(pwd)/%s)' % (test_file_name)
             ]
         else:
             bash_file += [
                 'export SINGULARITY_CACHEDIR="/tmp/$(whoami)/singularity"',
-                'singularity run -B /afs -B /cvmfs -B /etc/grid-security -B /etc/pki/ca-trust --no-home /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/$CONTAINER_NAME $(echo $(pwd)/%s)' % (test_file_name)
+                'singularity run --no-home /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/$CONTAINER_NAME $(echo $(pwd)/%s)' % (test_file_name)
             ]
 
         # Empty line at the end of the file

--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -2285,7 +2285,8 @@ class request(json_base):
                     # in case it keeps any output and produced 0 events
                     # means something is wrong in production
                     if (self.get_attribute('completed_events') <= 0
-                            and self.get_attribute("keep_output").count(True) > 0):
+                            and self.get_attribute("keep_output").count(True) > 0
+                            and not force):
 
                         not_good.update({
                             'message': '%s completed but with no statistics. stats DB lag. saving the request anyway.' % (

--- a/mcm/json_layer/request.py
+++ b/mcm/json_layer/request.py
@@ -1864,6 +1864,64 @@ class request(json_base):
 
         self.reload()
 
+    def _attempt_filter_workflows(self, mcm_reqmgr_name_list, stats_workflows):
+        """
+        Attempts to pick the latest injected workflows using the records available
+        in McM. After an injection process finishes, only the latest workflow name
+        is available on the `reqmgr_name` attribute with no content.
+
+        Note this filter process is not idempotent. In case the request has been
+        updated with previous data from Stats2, it is not possible to get the latest
+        workflow and nothing will be filtered. Such behavior is acceptable.
+
+        Args:
+            mcm_reqmgr_name_list (list[str]): List of ReqMgr2 workflow names available for
+                the request in McM.
+            stats_workflows (list[dict]): Stats2 workflow records related to the McM
+                request.
+
+        Returns:
+            list[dict]: Stats2 workflows possibly filtered by the latest injected
+                workflow. This could return the original list if the reference to
+                the latest injected workflow is not available or an empty list if
+                the latest injected workflow was not found in the provided list.
+        """
+        stats_workflows_dict = {
+            stats_workflow.get('RequestName'): stats_workflow
+            for stats_workflow in stats_workflows
+        }
+        workflows_to_consider = [
+            stats_workflows_dict.get(mcm_reqmgr_name)
+            for mcm_reqmgr_name in mcm_reqmgr_name_list
+            if stats_workflows_dict.get(mcm_reqmgr_name)
+        ]
+
+        self.logger.info("Workflows to consider: %s", [doc.get('RequestName') for doc in workflows_to_consider])
+        try:
+            # Pick the time related to the `new` transition
+            reference_time_of_new = min([
+                stats_doc.get('RequestTransition')[0].get('UpdateTime')
+                for stats_doc in workflows_to_consider
+            ])
+        except:
+            # There's no record for the latest injected workflow in Stats2.
+            return []
+
+        stats_reqmgr_name_list = [
+            reqmgr_name
+            for reqmgr_name, content in stats_workflows_dict.iteritems()
+            if content.get('RequestTransition') and
+                len(content['RequestTransition']) > 0 and
+                content['RequestTransition'][0].get('UpdateTime') is not None and
+                content['RequestTransition'][0]['UpdateTime'] >= reference_time_of_new
+        ]
+        self.logger.info(
+            "The following workflows may not be related to the last injection: %s",
+            set(stats_workflows_dict.keys()) - set(stats_reqmgr_name_list)
+        )
+
+        return stats_reqmgr_name_list
+
     def get_stats(self, forced=False):
         stats_db = database('requests', url='http://vocms074.cern.ch:5984/')
         prepid = self.get_attribute('prepid')
@@ -1872,9 +1930,18 @@ class request(json_base):
                                                   page=0,
                                                   limit=-1,
                                                   options={'key': prepid})
+
         mcm_reqmgr_list = self.get_attribute('reqmgr_name')
         mcm_reqmgr_name_list = [x['name'] for x in mcm_reqmgr_list]
-        stats_reqmgr_name_list = [stats_wf['RequestName'] for stats_wf in stats_workflows]
+        stats_workflows_dict = {
+            stats_workflow.get('RequestName'): stats_workflow
+            for stats_workflow in stats_workflows
+        }
+        stats_reqmgr_name_list = self._attempt_filter_workflows(mcm_reqmgr_name_list, stats_workflows)
+        if not stats_reqmgr_name_list:
+            # The workflows in mcm are too fresh and have not yet been registered in stats. update will have to wait.
+            return False
+
         all_reqmgr_name_list = list(set(mcm_reqmgr_name_list).union(set(stats_reqmgr_name_list)))
         all_reqmgr_name_list = sorted(all_reqmgr_name_list, key=lambda workflow: '_'.join(workflow.split('_')[-3:]))
         # self.logger.debug('Stats workflows for %s: %s' % (self.get_attribute('prepid'),
@@ -1893,12 +1960,7 @@ class request(json_base):
                                      'aborted-completed'])
         total_events = 0
         for reqmgr_name in all_reqmgr_name_list:
-            stats_doc = None
-            for stats_workflow in stats_workflows:
-                if stats_workflow.get('RequestName') == reqmgr_name:
-                    stats_doc = stats_workflow
-                    break
-
+            stats_doc = stats_workflows_dict.get(reqmgr_name, None)
             if not stats_doc and stats_db.document_exists(reqmgr_name):
                 self.logger.info('Workflow %s is in Stats DB, but workflow does not have request %s in it\'s list' % (reqmgr_name,
                                                                                                                       self.get_attribute('prepid')))

--- a/mcm/rest_api/ControlActions.py
+++ b/mcm/rest_api/ControlActions.py
@@ -124,17 +124,20 @@ class Search(RESTResource):
             for mccm in mccms:
                 args['prepid__'].extend(mccm.get('generated_chains', []).keys())
 
-        if not args and not sort_on:
-            # If there are no args, use simpler fetch
-            res = database.get_all(page, limit, with_total_rows=True)
-        else:
-            # Add types to arguments
-            args = {self.casting[db_name].get(k, k): v for k, v in args.items()}
-            # Construct the complex query
-            res = database.search(args, page, limit, include_fields, True, sort_on, sort_asc)
+        try:
+            if not args and not sort_on:
+                # If there are no args, use simpler fetch
+                res = database.get_all(page, limit, with_total_rows=True)
+            else:
+                # Add types to arguments
+                args = {self.casting[db_name].get(k, k): v for k, v in args.items()}
+                # Construct the complex query
+                res = database.search(args, page, limit, include_fields, True, sort_on, sort_asc)
 
-        res['results'] = res.pop('rows', [])
-        return self.output_text(res, 200, {'Content-Type': 'application/json'})
+            res['results'] = res.pop('rows', [])
+            return self.output_text(res, 200, {'Content-Type': 'application/json'})
+        except Exception as e:
+            return self.output_text({'message': str(e)}, 500, {'Content-Type': 'application/json'})
 
 
 class CacheInfo(RESTResource):

--- a/mcm/rest_api/ControlActions.py
+++ b/mcm/rest_api/ControlActions.py
@@ -124,20 +124,17 @@ class Search(RESTResource):
             for mccm in mccms:
                 args['prepid__'].extend(mccm.get('generated_chains', []).keys())
 
-        try:
-            if not args and not sort_on:
-                # If there are no args, use simpler fetch
-                res = database.get_all(page, limit, with_total_rows=True)
-            else:
-                # Add types to arguments
-                args = {self.casting[db_name].get(k, k): v for k, v in args.items()}
-                # Construct the complex query
-                res = database.search(args, page, limit, include_fields, True, sort_on, sort_asc)
+        if not args and not sort_on:
+            # If there are no args, use simpler fetch
+            res = database.get_all(page, limit, with_total_rows=True)
+        else:
+            # Add types to arguments
+            args = {self.casting[db_name].get(k, k): v for k, v in args.items()}
+            # Construct the complex query
+            res = database.search(args, page, limit, include_fields, True, sort_on, sort_asc)
 
-            res['results'] = res.pop('rows', [])
-            return self.output_text(res, 200, {'Content-Type': 'application/json'})
-        except Exception as e:
-            return self.output_text({'message': str(e)}, 500, {'Content-Type': 'application/json'})
+        res['results'] = res.pop('rows', [])
+        return self.output_text(res, 200, {'Content-Type': 'application/json'})
 
 
 class CacheInfo(RESTResource):

--- a/mcm/rest_api/ControlActions.py
+++ b/mcm/rest_api/ControlActions.py
@@ -124,21 +124,23 @@ class Search(RESTResource):
             for mccm in mccms:
                 args['prepid__'].extend(mccm.get('generated_chains', []).keys())
 
-        try:
-            if not args and not sort_on:
-                # If there are no args, use simpler fetch
-                res = database.get_all(page, limit, with_total_rows=True)
-            else:
-                # Add types to arguments
-                args = {self.casting[db_name].get(k, k): v for k, v in args.items()}
-                # Construct the complex query
-                res = database.search(args, page, limit, include_fields, True, sort_on, sort_asc)
+        if not args and not sort_on:
+            # If there are no args, use simpler fetch
+            res = database.get_all(page, limit, with_total_rows=True)
+        else:
+            # Add types to arguments
+            args = {self.casting[db_name].get(k, k): v for k, v in args.items()}
+            # Construct the complex query
+            res = database.search(args, page, limit, include_fields, True, sort_on, sort_asc)
 
-            res['results'] = res.pop('rows', [])
-            return self.output_text(res, 200, {'Content-Type': 'application/json'})
-        except Exception as e:
-            return self.output_text({'message': str(e)}, 500, {'Content-Type': 'application/json'})
+        response_code = 200
+        error_message = res.get('message')
+        if error_message and 'The database returned too much data' in error_message:
+            # The client performed a query that outbounds the limit.
+            response_code = 400
 
+        res['results'] = res.pop('rows', [])
+        return self.output_text(res, response_code, {'Content-Type': 'application/json'})
 
 class CacheInfo(RESTResource):
 


### PR DESCRIPTION
Instead of raising a `ValueError` that could be uncaught by other endpoints or internal functions, include an optional message on the database response to indicate errors related to the maximum response size for database queries.